### PR TITLE
feat: return 400 when query params causes error

### DIFF
--- a/src/controllers/statisticsController.ts
+++ b/src/controllers/statisticsController.ts
@@ -3,6 +3,7 @@ import { getDailyStatisticsView as getDailyStatistics } from "../services/statis
 import { dailyElectricityStatistics } from "@prisma/client";
 import { DailyElectricityData } from "../types/electricityData";
 import { QueryFilter, SortCriteria } from "../types/dataQueries";
+import { PrismaClientValidationError } from "@prisma/client/runtime/library";
 
 const parseFilters = <T>(filters: string) => {
   const queryFilters: QueryFilter<T> = {};
@@ -42,7 +43,6 @@ const parsedQueryParams = <T>(req: Request) => {
 
 export const handleGetDailyStatistics = async (req: Request, res: Response) => {
   try {
-    // Todo validate params and provide proper error response for invalid params
     const queryParams = parsedQueryParams<dailyElectricityStatistics>(req);
     const { data, totalRowCount } = await getDailyStatistics(queryParams);
     const response: DailyElectricityData = {
@@ -54,6 +54,10 @@ export const handleGetDailyStatistics = async (req: Request, res: Response) => {
     res.status(200).json(response);
   } catch (e) {
     console.error(e);
+    if (e instanceof PrismaClientValidationError) {
+      res.status(400).json({ error: "Invalid query parameters" });
+      return;
+    }
     res.status(500).json({ error: "Internal Server Error" });
   }
 };

--- a/src/services/statisticsService.ts
+++ b/src/services/statisticsService.ts
@@ -60,7 +60,6 @@ const createWhereClause = (
 export const getDailyStatisticsView = async (
   queryParams: QueryParams<dailyElectricityStatistics>
 ) => {
-  console.log(queryParams.pageSize, queryParams.pageStart);
   const [data, totalRowCount] = await Promise.all([
     await prisma.dailyElectricityStatistics.findMany({
       skip: queryParams.pageStart || DEFAULT_PAGE_START,


### PR DESCRIPTION
Catch the validation error from Prisma client and pass  statuscode 400 + message to indicate invalid query params